### PR TITLE
Add FTP TextDocumentContentProvider

### DIFF
--- a/tree-view-sample-plugin/package.json
+++ b/tree-view-sample-plugin/package.json
@@ -46,12 +46,12 @@
   "devDependencies": {
     "@theia/plugin": "next",
     "@theia/plugin-packager": "latest",
+    "@types/ftp": "^0.3.10",
     "rimraf": "2.6.2",
     "typescript-formatter": "7.2.2",
     "typescript": "2.9.2"
   },
   "dependencies": {
-    "@types/ftp": "^0.3.10",
     "ftp": "^0.3.10"
   },
   "scripts": {


### PR DESCRIPTION
Provides TextDocumentContentProvider for FTP resources.

Demonstrates an example with using `registerTextDocumentContentProvider` of Plugin API https://code.visualstudio.com/docs/extensionAPI/vscode-api#_workspace

Issue https://github.com/theia-ide/theia/issues/2786

![openftpresource](https://user-images.githubusercontent.com/1655894/47920292-5ff56080-deba-11e8-895f-a46128f87cdf.gif)
