### PR TITLE
Add sample for usage of workspace state and global state

### DIFF
--- a/key-value-storage/.gitignore
+++ b/key-value-storage/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+*.theia

--- a/key-value-storage/README.md
+++ b/key-value-storage/README.md
@@ -1,0 +1,10 @@
+## key-value-storage
+
+Simple Theia plugin that shows usage of plugin's key-value storage.
+
+Plugin has:
+
+ - global state (shared between all workspaces)
+ - workspace state (separate for each workspace)
+
+Both are accesible from plugin context.

--- a/key-value-storage/package.json
+++ b/key-value-storage/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "key-value-storage",
+  "publisher": "theia",
+  "keywords": [
+    "theia-plugin"
+  ],
+  "version": "0.0.1",
+  "license": "EPL-2.0",
+  "files": [
+    "src"
+  ],
+  "devDependencies": {
+    "@theia/plugin": "next",
+    "@theia/plugin-packager": "latest",
+    "rimraf": "2.6.2",
+    "typescript-formatter": "7.2.2",
+    "typescript": "2.9.2",
+    "ts-loader": "^4.1.0",
+    "clean-webpack-plugin": "^0.1.19",
+    "webpack": "^4.1.1",
+    "webpack-cli": "^3.1.1"
+  },
+  "scripts": {
+    "prepare": "yarn run clean && yarn run build",
+    "clean": "rimraf lib",
+    "format-code": "tsfmt -r",
+    "watch": "webpack-cli -w --config webpack.config.js",
+    "compile": "webpack-cli --config webpack.config.js",
+    "build": "yarn run format-code && yarn run compile && theia:plugin pack"
+  },
+  "engines": {
+    "theiaPlugin": "next"
+  },
+  "theiaPlugin": {
+    "frontend": "dist/key-value-storage-frontend.js"
+  }
+}

--- a/key-value-storage/src/key-value-storage-frontend.ts
+++ b/key-value-storage/src/key-value-storage-frontend.ts
@@ -1,0 +1,162 @@
+/**
+ * Sample which demonstarates usage of workspace state and global state of plugin.
+ *
+ * Provides commands for:
+ *  - setting / reading / deleting values in plugin global state of the plugin
+ *  - setting / reading / deleting values in workspace local state of the plugin
+ *  - command to set an object as a value
+ *
+ * Shows 'test' key from both storages at plugin startup and workspace changes.
+ */
+
+import * as theia from '@theia/plugin';
+
+export function start(context: theia.PluginContext) {
+
+    console.log('On start: global value by "test" key is: ', context.globalState.get('test'));
+    console.log('On start: workspace local value by "test" key is: ', context.workspaceState.get('test'));
+
+    context.subscriptions.push(
+        theia.workspace.onDidChangeWorkspaceFolders((event: theia.WorkspaceFoldersChangeEvent) => {
+            console.log('Workspace changed:', event);
+
+            console.log('On workspace changed: global value by "test" key is: ', context.globalState.get('test'));
+            console.log('On workspace changed: workspace local value by "test" key is: ', context.workspaceState.get('test'));
+        })
+    );
+
+    const AddObjectsAsValuesCommand = {
+        id: 'plugin-state-set-object-value',
+        label: "Plugin state: set object values to test key"
+    };
+    context.subscriptions.push(theia.commands.registerCommand(AddObjectsAsValuesCommand, (...args: any[]) => {
+        context.globalState.update('test', { 'field1': 'value1', 'field2': 64, 'obj': { 'sub1': 1, 'sub2': 'stringv' } });
+        context.workspaceState.update('test', { 'wsfield1': 'value1', 'wsfield2': 64, 'ws-obj': { 'sub1': 1, 'sub2': 'stringv' } });
+    }));
+
+    // Manual set / get / delete
+
+    const getGlobalCommand = {
+        id: 'plugin-state-get-global-state-by-key',
+        label: "Plugin State: get global value"
+    };
+    context.subscriptions.push(theia.commands.registerCommand(getGlobalCommand, async (...args: any[]) => {
+        const key = await askUserForKey();
+        if (key) {
+            const value: any = context.globalState.get(key);
+            showKeyValue(key, value);
+        }
+    }));
+
+    const setGlobalCommand = {
+        id: 'plugin-state-set-global-state-by-key',
+        label: "Plugin State: set global value"
+    };
+    context.subscriptions.push(theia.commands.registerCommand(setGlobalCommand, async (...args: any[]) => {
+        const { key, value } = await askUserForKeyValue();
+        if (key && value) {
+            context.globalState.update(key, value);
+            showUpdatedMessage(key, value);
+        }
+    }));
+
+    const deleteGlobalCommand = {
+        id: 'plugin-state-delete-global-state-by-key',
+        label: "Plugin State: delete global value"
+    };
+    context.subscriptions.push(theia.commands.registerCommand(deleteGlobalCommand, async (...args: any[]) => {
+        const key = await askUserForKey();
+        if (key) {
+            context.globalState.update(key, undefined);
+            showDeletedMessage(key);
+        }
+    }));
+
+    const getWorkspaceLocalCommand = {
+        id: 'plugin-state-get-workspace-local-state-by-key',
+        label: "Plugin State: get workspace local value"
+    };
+    context.subscriptions.push(theia.commands.registerCommand(getWorkspaceLocalCommand, async (...args: any[]) => {
+        const key = await askUserForKey();
+        if (key) {
+            const value: any = context.workspaceState.get(key);
+            showKeyValue(key, value);
+        }
+    }));
+
+    const setWorkspaceLocalCommand = {
+        id: 'plugin-state-set-workspace-local-state-by-key',
+        label: "Plugin State: set workspace local value"
+    };
+    context.subscriptions.push(theia.commands.registerCommand(setWorkspaceLocalCommand, async (...args: any[]) => {
+        const { key, value } = await askUserForKeyValue();
+        if (key && value) {
+            context.workspaceState.update(key, value);
+            showUpdatedMessage(key, value);
+        }
+    }));
+
+    const deleteWorkspaceLocalCommand = {
+        id: 'plugin-state-delete-workspace-local-state-by-key',
+        label: "Plugin State: delete workspace local value"
+    };
+    context.subscriptions.push(theia.commands.registerCommand(deleteWorkspaceLocalCommand, async (...args: any[]) => {
+        const key = await askUserForKey();
+        if (key) {
+            context.workspaceState.update(key, undefined);
+            showDeletedMessage(key);
+        }
+    }));
+
+    // Helper functions
+
+    function showKeyValue(key: string, value: any): void {
+        if (value) {
+            console.log('GET:', key, value);
+            theia.window.showInformationMessage(key + ' = ' + value.toString());
+        } else {
+            const message = 'There is no value for key: ' + key;
+            console.log(message);
+            theia.window.showInformationMessage(message);
+        }
+    }
+
+    function showUpdatedMessage(key: string, value: any) {
+        const message = 'Updated value for key: "' + key + '"';
+        console.log(message, value);
+        theia.window.showInformationMessage(message);
+    }
+
+    function showDeletedMessage(key: string): void {
+        const message = 'Value by key "' + key + '" has been deleted';
+        console.log(message);
+        theia.window.showInformationMessage(message);
+    }
+}
+
+interface KeyValue {
+    key: string | undefined;
+    value: string | undefined;
+}
+
+async function askUserForKey(): Promise<string | undefined> {
+    return theia.window.showInputBox({ placeHolder: 'key' });
+}
+
+async function askUserForKeyValue(): Promise<KeyValue> {
+    const key = await askUserForKey();
+    if (!key) {
+        // input was cancelled
+        return { key: undefined, value: undefined };
+    }
+
+    const value = await theia.window.showInputBox({ placeHolder: 'value' });
+    return {
+        key: key,
+        value: value
+    };
+}
+
+export function stop() {
+
+}

--- a/key-value-storage/tsconfig.json
+++ b/key-value-storage/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "experimentalDecorators": true,
+        "noUnusedLocals": true,
+        "emitDecoratorMetadata": true,
+        "downlevelIteration": true,
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "webworker"
+        ],
+        "sourceMap": true,
+        "rootDir": "src",
+        "outDir": "lib"
+    },
+    "include": [
+        "src"
+    ]
+}

--- a/key-value-storage/tsfmt.json
+++ b/key-value-storage/tsfmt.json
@@ -1,0 +1,18 @@
+{
+    "baseIndentSize": 0,
+    "newLineCharacter": "\n",
+    "indentSize": 4,
+    "tabSize": 4,
+    "indentStyle": 4,
+    "convertTabsToSpaces": true,
+    "insertSpaceAfterCommaDelimiter": true,
+    "insertSpaceAfterSemicolonInForStatements": true,
+    "insertSpaceBeforeAndAfterBinaryOperators": true,
+    "insertSpaceAfterKeywordsInControlFlowStatements": true,
+    "insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
+    "insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
+    "insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets": false,
+    "insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces": false,
+    "placeOpenBraceOnNewLineForFunctions": false,
+    "placeOpenBraceOnNewLineForControlBlocks": false
+}

--- a/key-value-storage/webpack.config.js
+++ b/key-value-storage/webpack.config.js
@@ -1,0 +1,47 @@
+/*********************************************************************
+* Copyright (c) 2018 Red Hat, Inc.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+**********************************************************************/
+
+const path = require('path');
+const CleanWebpackPlugin = require('clean-webpack-plugin');
+
+module.exports = {
+    entry: './src/key-value-storage-frontend.ts',
+    devtool: 'source-map',
+    mode: 'production',
+    module: {
+        rules: [
+            {
+                test: /\.ts$/,
+                use: [
+                    {
+                        loader: 'ts-loader',
+                    }
+                ],
+                exclude: /node_modules/
+            }
+        ]
+    },
+    plugins: [
+        new CleanWebpackPlugin(['dist'])
+    ],
+    resolve: {
+        extensions: ['.ts', '.js']
+    },
+    output: {
+        filename: 'key-value-storage-frontend.js',
+        libraryTarget: "var",
+        library: "theia_key_value_storage",
+
+        path: path.resolve(__dirname, 'dist')
+    },
+    externals: {
+        "@theia/plugin": "theia.theia_key_value_storage"
+    }
+};


### PR DESCRIPTION
Adds sample plugin which demonstrates usage of `globalState` and `workspaceState` key-value storage.

Related issue: https://github.com/theia-ide/theia/issues/3732