### PR TITLE
Add tooltip to TreeView sample plugin

### DIFF
--- a/samples/tree-view-sample-plugin/src/comments.ts
+++ b/samples/tree-view-sample-plugin/src/comments.ts
@@ -159,6 +159,7 @@ export class TestDataProvider implements theia.TreeDataProvider<string> {
             let gitLink = gitHubProfiles.get(element);
             return Promise.resolve({
                 label: element + (gitLink ? ` [GitHub](${gitLink})` : ''),
+                tooltip: 'Click the link to open user profile',
                 iconPath: 'fa-user medium-yellow',
                 command: {
                     id: ON_DID_SELECT_USER,


### PR DESCRIPTION
Display tooltip when hovering tree node in `tree-view-sample-plugin` 

Signed-off-by: che <che@eclipse.org>

This fix is required to test hot tooltips are displayed in pure Theia with only one `tree-view-sample-plugin`.

Part of the issue https://github.com/eclipse/che/issues/15260
